### PR TITLE
test: add simple endpoint tests for events and subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /grid
+coverage.out

--- a/grid_test.go
+++ b/grid_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/boson-project/grid"
 )
 
+func StartGrid() (g *grid.Grid, err error) {
+	listening := make(chan bool)
+	errCh := make(chan error)
+
+	g = grid.New(
+		grid.WithAddress("127.0.0.1:"),                  // OS-chosen port
+		grid.WithOnListen(func() { listening <- true }), // signal start
+	)
+
+	go func() {
+		if err := g.Serve(context.Background()); err != nil {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case err = <-errCh:
+	case <-listening:
+	}
+	return g, err
+}
+
 // TestCancel ensures the service starts and stops without error with all defaults using
 // a cancelable context.
 func TestStart(t *testing.T) {
@@ -25,22 +47,42 @@ func TestStart(t *testing.T) {
 
 // TestVersion ensures that the /v1/version endpoint returns the version structure.
 func TestVersion(t *testing.T) {
-	listening := make(chan bool)
-
-	g := grid.New(
-		grid.WithAddress("127.0.0.1:"),                  // OS-chosen port
-		grid.WithOnListen(func() { listening <- true }), // signal start
-	)
-
-	go func() {
-		if err := g.Serve(context.Background()); err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	<-listening // Wait for start signal
+	g, err := StartGrid()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	res, err := http.Get("http://" + g.Addr().String() + "/v1/version")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("Expected HTTP 200, got %v", res.StatusCode)
+	}
+}
+
+func TestEventsEndpointAvailable(t *testing.T) {
+	g, err := StartGrid()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.Get("http://" + g.Addr().String() + "/v1/events")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.StatusCode != 200 {
+		t.Fatalf("Expected HTTP 200, got %v", res.StatusCode)
+	}
+}
+
+func TestSubscriptionsEndpointAvailable(t *testing.T) {
+	g, err := StartGrid()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := http.Get("http://" + g.Addr().String() + "/v1/subscriptions")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/grid_test.go
+++ b/grid_test.go
@@ -8,7 +8,9 @@ import (
 	"github.com/boson-project/grid"
 )
 
-func StartGrid() (g *grid.Grid, err error) {
+func StartGrid(t *testing.T) (g *grid.Grid, err error) {
+	t.Helper()
+
 	listening := make(chan bool)
 	errCh := make(chan error)
 
@@ -47,7 +49,7 @@ func TestStart(t *testing.T) {
 
 // TestVersion ensures that the /v1/version endpoint returns the version structure.
 func TestVersion(t *testing.T) {
-	g, err := StartGrid()
+	g, err := StartGrid(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -62,7 +64,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestEventsEndpointAvailable(t *testing.T) {
-	g, err := StartGrid()
+	g, err := StartGrid(t)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +79,7 @@ func TestEventsEndpointAvailable(t *testing.T) {
 }
 
 func TestSubscriptionsEndpointAvailable(t *testing.T) {
-	g, err := StartGrid()
+	g, err := StartGrid(t)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/handler_test.go
+++ b/handler_test.go
@@ -1,3 +1,24 @@
 package grid
 
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestVersionHandler(t *testing.T) {
+	g := New(
+		WithAddress("127.0.0.1:"),
+	)
+
+	req := httptest.NewRequest("GET", "http://127.0.0.1/version", nil)
+	w := httptest.NewRecorder()
+	g.handleVersion(w, req)
+
+	resp := w.Result()
+
+	if resp.StatusCode != 200 {
+		t.Error("Expected status code 200")
+	}
+}
+
 // TODO: handler unit tests using httptest


### PR DESCRIPTION
This commit adds two simple tests for the events and subscription endpoints,
just ensuring that they exist. Also, to reduce code duplication, extracted
a `StartGrid()` function for reuse in multiple tests.

Also added a stubbed unit test for version handler.